### PR TITLE
fix typo in dependencies (pycrypo to pycrypto)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(name='aiotuya',
     ],
     install_requires=[
         'aiohttp',
-        'pycrypo',
+        'pycrypto',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
fixed the error when installing with `pip3 install .` which otherwise
results in the following:

ERROR: Could not find a version that satisfies the requirement pycrypo (from aiotuya==0.1.0b2) (from versions: none)
ERROR: No matching distribution found for pycrypo (from aiotuya==0.1.0b2)